### PR TITLE
Swpbl-190339 -- Serialize graph to JSON after quitting app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ add_executable(Dynamite
     ${CMAKE_SOURCE_DIR}/example/Dynamite/palette.cpp
     ${CMAKE_SOURCE_DIR}/example/Dynamite/multipanel.cpp
     ${CMAKE_SOURCE_DIR}/example/Dynamite/dyndsp_wrapper.cpp
+    ${CMAKE_SOURCE_DIR}/example/Dynamite/JsonGraphFileWriter.cpp
     )
 target_link_libraries(Dynamite imnodes SDL2::SDL2)
 target_link_libraries(Dynamite ${Python_LIBRARIES})

--- a/example/Dynamite/GraphFileWriter.h
+++ b/example/Dynamite/GraphFileWriter.h
@@ -1,0 +1,7 @@
+#include "context.h"
+
+class GraphFileWriter {
+
+    public: 
+        virtual void writeToFile(Context& context) = 0;
+};

--- a/example/Dynamite/JsonGraphFileWriter.cpp
+++ b/example/Dynamite/JsonGraphFileWriter.cpp
@@ -51,6 +51,8 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
     Value block;
 
     for (Block& b: context._blocks) {
+        if ((0 == strcmp(b.getType().c_str(), "input")) || (0 == strcmp(b.getType().c_str(), "output"))) continue;
+        
         block.SetObject();
         s = StringRef(b.name);
         block.AddMember("name", s, allocator);
@@ -79,17 +81,19 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
 
         Value param;
         param.SetObject();
-        if (!b._parameters.empty()) {
-            map<int,Parameter>::iterator itp;
-            for (itp = b._parameters.begin(); itp != b._parameters.end(); itp++) {
-                Value n; n = StringRef(itp->second.name);
+        map<int,Parameter>::iterator itp;
+        for (itp = b._parameters.begin(); itp != b._parameters.end(); itp++) {
+            if (itp->second.name != "none") {
+                Value n; n = StringRef(itp->second.name.c_str());
                 Value v; v = StringRef(itp->second.value);
                 param.AddMember(n, v, allocator);
             }
-            Value t; t = StringRef(b.getType());
-            block.AddMember(t, param, allocator);
-        dsp_blocks.PushBack(block, allocator);
         }
+        //Value t(b.getType().c_str(), b.getType(),size(), allocator);
+        //t = StringRef(b.getType());
+    
+        block.AddMember(Value(b.getType().c_str(), b.getType().size(), allocator).Move(), param, allocator);
+        dsp_blocks.PushBack(block, allocator);
     }
     jsonDoc.AddMember("dsp_blocks", dsp_blocks, allocator);
 

--- a/example/Dynamite/JsonGraphFileWriter.cpp
+++ b/example/Dynamite/JsonGraphFileWriter.cpp
@@ -1,13 +1,13 @@
 #include "JsonGraphFileWriter.h"
 
+/*
+ERRORS: 
+- finding it difficult to change block input/output names and adding new ones -> clicking on the mpp boxes is weird
+- must use string literal with AddmMember(), can't assign specific block values to value arg
+*/
+
 void JsonGraphFileWriter::writeToFile(Context& context) {
     // set up .json file
-    /* method 1
-    ofstream ofs("system.json");    // create output file
-    OStreamWrapper osw(ofs);        // stream wrapper
-    Writer<OStreamWrapper> writer(osw); // writter for the stream wrapper
-    */
-    // method 2
     FILE* fp = fopen("system.json", "w");
     char buffer[65536];
     FileWriteStream fs(fp, buffer, sizeof(buffer));
@@ -32,52 +32,49 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
 
     Value dsp_blocks(kArrayType); // AddMember("dsp_blocks", dsp_blocks, jsonDoc.GetAllocator()) is the last line
     Value block;
-    block.SetObject();
 
-    string name = "input";
-    auto iter = std::find_if(
-    context._blocks.begin(), context._blocks.end(), [name](Block& block) -> bool {
-        return block.getName() == name;
-    });
-    block.AddMember("name", "input", allocator);
+    for (Block& b: context._blocks) {
+        block.SetObject();
+        block.AddMember("name", "block name", allocator);
 
-    Value input_chans(kArrayType);
-    map<int, Port>::iterator it;
-    for (it = iter->_inPorts.begin(); it != iter->_inPorts.end(); it++) {
-        Value input_ch;
-        input_ch.SetObject();
-        //input_ch.AddMember("name", it->second.c_str(), allocator);
-        input_ch.AddMember("name", "input", allocator);
-        input_chans.PushBack(input_ch, allocator);
+        Value input_chans(kArrayType);
+        map<int, Port>::iterator it;
+        for (it = b._inPorts.begin(); it != b._inPorts.end(); it++) {
+            Value input_ch;
+            input_ch.SetObject();
+            /*
+            string s = it->second.type;
+            Value type(s.c_str(), s.size(), allocator);
+            input_ch.AddMember("name", s, allocator); */
+            input_ch.AddMember("name", "input", allocator);
+            input_chans.PushBack(input_ch, allocator);
+        }
+        block.AddMember("input_channels", input_chans, allocator);
+
+        Value output_chans(kArrayType);
+        for (it = b._outPorts.begin(); it != b._outPorts.end(); it++) {
+            Value output_ch;
+            output_ch.SetObject();
+            //output_ch.AddMember("name", it->second.c_str(), allocator);
+            output_ch.AddMember("name", "output", allocator);
+            output_chans.PushBack(output_ch, allocator);
+        }
+        block.AddMember("output_channels", output_chans, allocator);
+
+        /*
+        Value param;
+        param.SetObject();
+        map<int,Parameter>::iterator itp;
+        for (itp = iter->_parameters.begin(); itp != iter->_parameters.end(); itp++) {
+            param.AddMember(iter->second.name, iter->second.value, allocator);
+        }
+        block.AddMember(iter->getName, param, allocator);
+        */
+
+       dsp_blocks.PushBack(block, allocator);
     }
-    block.AddMember("input_channels", input_chans, allocator);
-
-    Value output_chans(kArrayType);
-    for (it = iter->_outPorts.begin(); it != iter->_outPorts.end(); it++) {
-        Value output_ch;
-        output_ch.SetObject();
-        //output_ch.AddMember("name", it->second.c_str(), allocator);
-        output_ch.AddMember("name", "output", allocator);
-        output_chans.PushBack(output_ch, allocator);
-    }
-    block.AddMember("output_channels", output_chans, allocator);
-
-    /*
-    Value param;
-    param.SetObject();
-    map<int,Parameter>::iterator itp;
-    for (itp = iter->_parameters.begin(); itp != iter->_parameters.end(); itp++) {
-        param.AddMember(iter->second.name, iter->second.value, allocator);
-    }
-    block.AddMember(iter->getName, param, allocator);
-    */
-    dsp_blocks.PushBack(block, allocator);
-    /*
-    iterate over blocks
-    add each block to t
-    block.SetObject();
-    */
     jsonDoc.AddMember("dsp_blocks", dsp_blocks, allocator);
+
     // write to file
     jsonDoc.Accept(pwriter);
 }

--- a/example/Dynamite/JsonGraphFileWriter.cpp
+++ b/example/Dynamite/JsonGraphFileWriter.cpp
@@ -1,11 +1,5 @@
 #include "JsonGraphFileWriter.h"
 
-/*
-ERRORS: 
-- finding it difficult to change block input/output names and adding new ones -> clicking on the mpp boxes is weird
-- must use string literal with AddmMember(), can't assign specific block values to value arg
-*/
-
 void JsonGraphFileWriter::writeToFile(Context& context) {
     // set up .json file
     FILE* fp = fopen("system.json", "w");
@@ -19,34 +13,55 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
     jsonDoc.SetObject();    // set the current document as an object, that is, the entire doc is an object type DOM element
 
     // populate data
+    Value s;
     jsonDoc.AddMember("name", "DSPSystemDynamite", allocator);
-    Value in_ch_ar(kArrayType);
-    Value channel;
-    channel.SetObject();
-    channel.AddMember("name", "IN_L", allocator);
-    in_ch_ar.PushBack(channel, allocator);
-    channel.SetObject();
-    channel.AddMember("name", "IN_R", allocator);
-    in_ch_ar.PushBack(channel, allocator);
-    jsonDoc.AddMember("input_channels", in_ch_ar, allocator);
 
-    Value dsp_blocks(kArrayType); // AddMember("dsp_blocks", dsp_blocks, jsonDoc.GetAllocator()) is the last line
+    Value in_ch_ar(kArrayType);
+    for (Block& b : context._blocks) {
+        if (b.getType() == "input") {
+            map<int, Port>::iterator it;
+            for (it = b._outPorts.begin(); it != b._outPorts.end(); it++) {
+                Value channel;
+                channel.SetObject();
+                s = StringRef(it->second.name);
+                channel.AddMember("name", s, allocator);
+                in_ch_ar.PushBack(channel, allocator);
+            }
+            jsonDoc.AddMember("input_channels", in_ch_ar, allocator);
+        }
+    }
+
+    Value out_ch_ar(kArrayType);
+    for (Block& b : context._blocks) {
+        if (b.getType() == "output") {
+            map<int, Port>::iterator it;
+            for (it = b._inPorts.begin(); it != b._inPorts.end(); it++) {
+                Value channel;
+                channel.SetObject();
+                Value o;
+                o = StringRef(it->second.name);
+                channel.AddMember("name", o, allocator);
+                out_ch_ar.PushBack(channel, allocator);
+            }
+            jsonDoc.AddMember("output_channels", out_ch_ar, allocator);
+        }
+    }
+
+    Value dsp_blocks(kArrayType);
     Value block;
 
     for (Block& b: context._blocks) {
         block.SetObject();
-        block.AddMember("name", "block name", allocator);
+        s = StringRef(b.name);
+        block.AddMember("name", s, allocator);
 
         Value input_chans(kArrayType);
         map<int, Port>::iterator it;
         for (it = b._inPorts.begin(); it != b._inPorts.end(); it++) {
             Value input_ch;
             input_ch.SetObject();
-            /*
-            string s = it->second.type;
-            Value type(s.c_str(), s.size(), allocator);
-            input_ch.AddMember("name", s, allocator); */
-            input_ch.AddMember("name", "input", allocator);
+            s = StringRef(it->second.name);
+            input_ch.AddMember("name", s, allocator);
             input_chans.PushBack(input_ch, allocator);
         }
         block.AddMember("input_channels", input_chans, allocator);
@@ -55,23 +70,26 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
         for (it = b._outPorts.begin(); it != b._outPorts.end(); it++) {
             Value output_ch;
             output_ch.SetObject();
-            //output_ch.AddMember("name", it->second.c_str(), allocator);
-            output_ch.AddMember("name", "output", allocator);
+            Value s;
+            s = StringRef(it->second.name);
+            output_ch.AddMember("name", s, allocator);
             output_chans.PushBack(output_ch, allocator);
         }
         block.AddMember("output_channels", output_chans, allocator);
 
-        /*
         Value param;
         param.SetObject();
-        map<int,Parameter>::iterator itp;
-        for (itp = iter->_parameters.begin(); itp != iter->_parameters.end(); itp++) {
-            param.AddMember(iter->second.name, iter->second.value, allocator);
+        if (!b._parameters.empty()) {
+            map<int,Parameter>::iterator itp;
+            for (itp = b._parameters.begin(); itp != b._parameters.end(); itp++) {
+                Value n; n = StringRef(itp->second.name);
+                Value v; v = StringRef(itp->second.value);
+                param.AddMember(n, v, allocator);
+            }
+            Value t; t = StringRef(b.getType());
+            block.AddMember(t, param, allocator);
+        dsp_blocks.PushBack(block, allocator);
         }
-        block.AddMember(iter->getName, param, allocator);
-        */
-
-       dsp_blocks.PushBack(block, allocator);
     }
     jsonDoc.AddMember("dsp_blocks", dsp_blocks, allocator);
 

--- a/example/Dynamite/JsonGraphFileWriter.cpp
+++ b/example/Dynamite/JsonGraphFileWriter.cpp
@@ -1,0 +1,83 @@
+#include "JsonGraphFileWriter.h"
+
+void JsonGraphFileWriter::writeToFile(Context& context) {
+    // set up .json file
+    /* method 1
+    ofstream ofs("system.json");    // create output file
+    OStreamWrapper osw(ofs);        // stream wrapper
+    Writer<OStreamWrapper> writer(osw); // writter for the stream wrapper
+    */
+    // method 2
+    FILE* fp = fopen("system.json", "w");
+    char buffer[65536];
+    FileWriteStream fs(fp, buffer, sizeof(buffer));
+    PrettyWriter<FileWriteStream> pwriter(fs);
+
+    // create DOM document
+    Document jsonDoc; // generate a DOM element document
+    Document::AllocatorType &allocator = jsonDoc.GetAllocator();    // get allocator
+    jsonDoc.SetObject();    // set the current document as an object, that is, the entire doc is an object type DOM element
+
+    // populate data
+    jsonDoc.AddMember("name", "DSPSystemDynamite", allocator);
+    Value in_ch_ar(kArrayType);
+    Value channel;
+    channel.SetObject();
+    channel.AddMember("name", "IN_L", allocator);
+    in_ch_ar.PushBack(channel, allocator);
+    channel.SetObject();
+    channel.AddMember("name", "IN_R", allocator);
+    in_ch_ar.PushBack(channel, allocator);
+    jsonDoc.AddMember("input_channels", in_ch_ar, allocator);
+
+    Value dsp_blocks(kArrayType); // AddMember("dsp_blocks", dsp_blocks, jsonDoc.GetAllocator()) is the last line
+    Value block;
+    block.SetObject();
+
+    string name = "input";
+    auto iter = std::find_if(
+    context._blocks.begin(), context._blocks.end(), [name](Block& block) -> bool {
+        return block.getName() == name;
+    });
+    block.AddMember("name", "input", allocator);
+
+    Value input_chans(kArrayType);
+    map<int, Port>::iterator it;
+    for (it = iter->_inPorts.begin(); it != iter->_inPorts.end(); it++) {
+        Value input_ch;
+        input_ch.SetObject();
+        //input_ch.AddMember("name", it->second.c_str(), allocator);
+        input_ch.AddMember("name", "input", allocator);
+        input_chans.PushBack(input_ch, allocator);
+    }
+    block.AddMember("input_channels", input_chans, allocator);
+
+    Value output_chans(kArrayType);
+    for (it = iter->_outPorts.begin(); it != iter->_outPorts.end(); it++) {
+        Value output_ch;
+        output_ch.SetObject();
+        //output_ch.AddMember("name", it->second.c_str(), allocator);
+        output_ch.AddMember("name", "output", allocator);
+        output_chans.PushBack(output_ch, allocator);
+    }
+    block.AddMember("output_channels", output_chans, allocator);
+
+    /*
+    Value param;
+    param.SetObject();
+    map<int,Parameter>::iterator itp;
+    for (itp = iter->_parameters.begin(); itp != iter->_parameters.end(); itp++) {
+        param.AddMember(iter->second.name, iter->second.value, allocator);
+    }
+    block.AddMember(iter->getName, param, allocator);
+    */
+    dsp_blocks.PushBack(block, allocator);
+    /*
+    iterate over blocks
+    add each block to t
+    block.SetObject();
+    */
+    jsonDoc.AddMember("dsp_blocks", dsp_blocks, allocator);
+    // write to file
+    jsonDoc.Accept(pwriter);
+}

--- a/example/Dynamite/JsonGraphFileWriter.h
+++ b/example/Dynamite/JsonGraphFileWriter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define __STDC_WANT_LIB_EXT1__ 1
+#define RAPIDJSON_HAS_STDSTRING 1
 #include "GraphFileWriter.h"
 #include "block.h"
 #include "rapidjson/document.h"

--- a/example/Dynamite/JsonGraphFileWriter.h
+++ b/example/Dynamite/JsonGraphFileWriter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#define __STDC_WANT_LIB_EXT1__ 1
+#include "GraphFileWriter.h"
+#include "block.h"
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/filewritestream.h"
+#include "rapidjson/istreamwrapper.h"
+#include "rapidjson/ostreamwrapper.h"
+#include "rapidjson/prettywriter.h"
+#include <iostream>
+#include <fstream>
+#include <stdio.h>
+
+using namespace rapidjson;
+using namespace std;
+
+struct Port;
+
+class JsonGraphFileWriter : public GraphFileWriter {
+    public:
+        //~JsonGraphFileWriter() { cout << "Deconstructor for json file writer called." << endl; }
+        void writeToFile(Context& context);
+};
+
+
+
+
+
+
+
+
+

--- a/example/Dynamite/block.cpp
+++ b/example/Dynamite/block.cpp
@@ -25,7 +25,7 @@ string Block::getName() {
 }
 
 string Block::getType() {
-    return this->type;
+    return this->type.c_str();
 }
 
 int Block::getNumInputs() {

--- a/example/Dynamite/dynamite.cpp
+++ b/example/Dynamite/dynamite.cpp
@@ -14,6 +14,8 @@ bool Dynamite::show(bool done) {
 
 void Dynamite::exit() {
     m_ui.exit();
+    JsonGraphFileWriter fw;
+    fw.writeToFile(m_context);
 }
 
 

--- a/example/Dynamite/dynamite.h
+++ b/example/Dynamite/dynamite.h
@@ -5,6 +5,7 @@
 
 #include "ui.h"
 #include "context.h"
+#include "JsonGraphFileWriter.h"
 #include <string>
 
 using namespace std;

--- a/example/Dynamite/menubar.cpp
+++ b/example/Dynamite/menubar.cpp
@@ -2,7 +2,6 @@
 
 struct MenuAction {
     string name; 
-    //lambda menuAction; 
 };
 
 struct SubMenu {


### PR DESCRIPTION
### **OVERVIEW**

After designing a DSP system in the editor, the user would like to see that system written out in JSON format, so that the system can later be validated. We can now add an input block to the system, and see its output channels listed in as an array before the blocks, as well as the input channels for an output block. Each block in the system, its inputs, outputs, and parameters are also serialized in a file "system.json", which can be found in the imnodes root directory. 

### **To test**
In the project root directory, run the following commands:
```
git clone https://github.com/Tencent/rapidjson.git
```
Then, copy the include/rapidjson folder into the imnodes directory. Now, you can compile as usual and build a system in the app editor. After quitting the session, look in your root directory for "system.json". 