### PR TITLE
SWPBL-189719 -- run validate() from menu bar

### DIFF
--- a/example/Dynamite/JsonGraphFileWriter.cpp
+++ b/example/Dynamite/JsonGraphFileWriter.cpp
@@ -99,4 +99,5 @@ void JsonGraphFileWriter::writeToFile(Context& context) {
 
     // write to file
     jsonDoc.Accept(pwriter);
+    fclose(fp);
 }

--- a/example/Dynamite/dynamite.cpp
+++ b/example/Dynamite/dynamite.cpp
@@ -14,8 +14,6 @@ bool Dynamite::show(bool done) {
 
 void Dynamite::exit() {
     m_ui.exit();
-    JsonGraphFileWriter fw;
-    fw.writeToFile(m_context);
 }
 
 

--- a/example/Dynamite/dynamite.h
+++ b/example/Dynamite/dynamite.h
@@ -5,7 +5,6 @@
 
 #include "ui.h"
 #include "context.h"
-#include "JsonGraphFileWriter.h"
 #include <string>
 
 using namespace std;

--- a/example/Dynamite/dyndsp_wrapper.cpp
+++ b/example/Dynamite/dyndsp_wrapper.cpp
@@ -21,9 +21,7 @@ void DyndspWrapper::validate() {
         CPyObject pCommand = PyObject_GetAttrString(pModule, "list_rules");
 
         if (pCommand && PyCallable_Check(pCommand)) {
-            // Create argument to send over
             CPyObject pRules = PyObject_CallObject(pCommand, NULL);
-            if (pRules) printf("validated\n");
         }
         else {
             printf("ERROR: function validate()\n");

--- a/example/Dynamite/dyndsp_wrapper.cpp
+++ b/example/Dynamite/dyndsp_wrapper.cpp
@@ -18,7 +18,7 @@ void DyndspWrapper::validate() {
 
     if (pModule) {
         // Find the method defined in Python file
-        CPyObject pCommand = PyObject_GetAttrString(pModule, "list_rules");
+        CPyObject pCommand = PyObject_GetAttrString(pModule, "validate");
 
         if (pCommand && PyCallable_Check(pCommand)) {
             CPyObject pRules = PyObject_CallObject(pCommand, NULL);

--- a/example/Dynamite/dyndsp_wrapper.cpp
+++ b/example/Dynamite/dyndsp_wrapper.cpp
@@ -1,13 +1,37 @@
 #include "dyndsp_wrapper.h" 
-#include <Python.h>
-#include "pyhelper.h"
-#include <vector>
-#include <string>
 
 using namespace std;
 
 // Single initialization of Python interpreter
 CPyInstance hInstance;
+
+void DyndspWrapper::validate() {
+    static std::vector<std::string> dsp_blocknames;
+
+    // Provide path for Python to find file
+    PyRun_SimpleString("import sys");
+    PyRun_SimpleString("sys.path.append(\"./example/Dynamite\")");
+
+    // Find a Python file named run_test.py
+    CPyObject pName = PyUnicode_FromString("run_test");
+    CPyObject pModule = PyImport_Import(pName);
+
+    if (pModule) {
+        // Find the method defined in Python file
+        CPyObject pCommand = PyObject_GetAttrString(pModule, "list_rules");
+
+        if (pCommand && PyCallable_Check(pCommand)) {
+            // Create argument to send over
+            CPyObject pRules = PyObject_CallObject(pCommand, NULL);
+            if (pRules) printf("validated\n");
+        }
+        else {
+            printf("ERROR: function validate()\n");
+        }
+    } else {
+        printf("ERROR: Module not imported\n");
+    }
+}
 
 std::vector<std::string> DyndspWrapper::get_dsp_list() 
 {

--- a/example/Dynamite/dyndsp_wrapper.h
+++ b/example/Dynamite/dyndsp_wrapper.h
@@ -2,9 +2,14 @@
 
 #include <vector>
 #include <string>
+#include <fstream>
+
+#include <Python.h>
+#include "pyhelper.h"
 
 class DyndspWrapper {
     public:
+        void validate();
         std::vector<std::string> get_dsp_list();
         std::vector<std::string> get_control_list();
         std::vector<std::string> get_parameter_names(std::string block_name);

--- a/example/Dynamite/menubar.cpp
+++ b/example/Dynamite/menubar.cpp
@@ -1,17 +1,26 @@
 #include "menubar.h"
 
+static bool save = false;
 static bool command = false;
-static void validate();
+static void saveToJson(Context& m_context);
 
 CPyInstance hInst;
 
-void MenuBar::show() {
+void MenuBar::show(Context& m_context) {
+    if (save) saveToJson(m_context);
+    if (command)  {
+        m_context.m_wrapper.validate();
+        command = false;
+    }
+
     if (ImGui::BeginMenuBar()) {
         if (ImGui::BeginMenu("File")) {
             vector<std::string> menuItems { "New", "Open", "Save", "Save as", "Import", "Export", "Close"  };
             //createMenu(menuItems);
             for (auto Item : menuItems) {
-                if (ImGui::MenuItem(Item.c_str(), NULL)) {
+                if (strcmp(Item.c_str(), "Save") == 0) {
+                    ImGui::MenuItem(Item.c_str(), NULL, &save);
+                } else if (ImGui::MenuItem(Item.c_str(), NULL)) {
                     printf("menu opened!\n");
                 }
             }
@@ -28,8 +37,6 @@ void MenuBar::show() {
             }
             ImGui::EndMenu();
         }
-
-        if (command) validate();
 
         if (ImGui::BeginMenu("Commands")) {
             vector<std::string> menuItems { "Validate", "Generate", "Fetch", "Deploy", "Clean" };
@@ -54,34 +61,10 @@ void MenuBar::show() {
     } 
 }
 
-static void validate() {
-    // Provide path for Python to find file
-    PyRun_SimpleString("import sys");
-    
-    // Find a Python file named run_test.py
-    CPyObject pName = PyUnicode_FromString("sonos.audio.dynamicdsp.commands.v1alpha1");
-    CPyObject pModule = PyImport_Import(pName);
-
-    if (pModule) {
-        printf("module accessed\n");
-        CPyObject pCommand = PyObject_GetAttrString(pModule, "validate");
-
-        if (pCommand && PyCallable_Check(pCommand)) {
-            printf("can open command\n");
-            //Create argument to send over
-            CPyObject pArg = PySys_GetObject("system.json");
-            CPyObject pRules = PyObject_CallObject(pCommand, pArg);
-
-            auto listRulesSize = PyList_Size(pRules);
-            for (Py_ssize_t j = 0 ; j < listRulesSize; ++j)
-            {
-                PyObject* rules = PyList_GetItem(pRules, j);
-                string rule(PyUnicode_AsUTF8(rules));
-                printf("Rules : %s\n", rule.c_str());
-            }
-        }
-    }
-    command = false;
+static void saveToJson(Context& m_context) {
+    JsonGraphFileWriter fw;
+    fw.writeToFile(m_context);
+    save = false;
 }
 
 /*

--- a/example/Dynamite/menubar.h
+++ b/example/Dynamite/menubar.h
@@ -3,6 +3,8 @@
 #include <imgui.h>
 #include <vector>
 #include <string>
+#include "context.h"
+#include "JsonGraphFileWriter.h"
 
 #include <Python.h>
 #include "pyhelper.h"
@@ -33,7 +35,7 @@ vector<SubMenus>
 
 class MenuBar {
 public:
-    void show();
+    void show(Context &m_context);
     //void createMenu(vector<std::string> &menuItems);
     //void createMenu(vector<std::string> menuItems);
 

--- a/example/Dynamite/menubar.h
+++ b/example/Dynamite/menubar.h
@@ -4,11 +4,37 @@
 #include <vector>
 #include <string>
 
+#include <Python.h>
+#include "pyhelper.h"
+
 using namespace std;
+
+struct MenuAction {
+    string name; 
+};
+
+struct SubMenu {
+    string name;
+    std::vector<MenuAction> menuItems; 
+};
+
+// menubar owns static copies of the structs
+// functions may not be static couz they are passed in at runtime
+// or use a function pointer
+/* 
+vector<MenuActions> = { name, action }
+
+vector<SubMenus>
+*/
+
+// document the editorcontext use cases into the google doc
+// creating subsystems, lives only in the app side of things, but not the code 
+// only the UI knows its a subsystem, click on it and see the context contained
 
 class MenuBar {
 public:
     void show();
     //void createMenu(vector<std::string> &menuItems);
     //void createMenu(vector<std::string> menuItems);
+
 };

--- a/example/Dynamite/run_test.py
+++ b/example/Dynamite/run_test.py
@@ -58,7 +58,7 @@ def list_param_types(block_name):
     return block_param_types
 
 
-def list_rules(): 
+def validate(): 
     api_version = sonos.audio.dynamicdsp.ApiVersion.v1alpha1
     f = open("system.json", 'r')
 

--- a/example/Dynamite/run_test.py
+++ b/example/Dynamite/run_test.py
@@ -48,3 +48,9 @@ def list_param_types(block_name):
         return ["none"]
     print(block_param_types)
     return block_param_types
+
+
+def list_rules(): 
+    api_version = sonos.audio.dynamicdsp.ApiVersion.v1alpha1
+    f = open("system.json", 'r')
+    rules_output = sonos.audio.dynamicdsp.commands.validate(api_version, f)

--- a/example/Dynamite/ui.cpp
+++ b/example/Dynamite/ui.cpp
@@ -97,7 +97,7 @@ bool UI::show(bool done, Context &m_context) {
     ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x, ImGui::GetIO().DisplaySize.y * 0.75f));
     auto flags = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize;
     ImGui::Begin("Dynamite Editor", NULL, flags); // begin menu bar + canvas + multipanel window
-    m_menu.show(); 
+    m_menu.show(m_context); 
 
     UI::setSplitter();
     Splitter(true, s_SplitterSize, &s_LeftPaneSize, &s_RightPaneSize, 100.0f, 100.0f);


### PR DESCRIPTION
**OVERVIEW**
The user can now create a DSP system in the editor, and generate a JSON file description of that system , saved to "system.json" in the cwd. In addition, we can now run the sonos.audio.dynamicdsp.command validate() command on that file from the Commands->Validate menu bar item. 

**TO TEST**
Run Dynamite, then start creating a system in the editor. Once you are satisfied with your system, go to the File->Save to save your system as a JSON file. Once saved, you can select the validate command to validate that system. 

**NOTES**
1. EDIT : all prints are visible in the console! In a future PR, those prints will be added to the multi-purpose panel, as well as trigger a toast notification
2. As long as a file named "system.json" exists in your cwd, you can run the validate() command, regardless of its contents. The "system.json" does not get updated until you save a new system to it, overwriting the previous system. 