### PR TITLE
SWPBL-190856 -- build adjacency list from graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(Dynamite
     ${CMAKE_SOURCE_DIR}/example/Dynamite/multipanel.cpp
     ${CMAKE_SOURCE_DIR}/example/Dynamite/dyndsp_wrapper.cpp
     ${CMAKE_SOURCE_DIR}/example/Dynamite/JsonGraphFileWriter.cpp
+    ${CMAKE_SOURCE_DIR}/example/Dynamite/graph.cpp
     )
 target_link_libraries(Dynamite imnodes SDL2::SDL2)
 target_link_libraries(Dynamite ${Python_LIBRARIES})

--- a/example/Dynamite/context.cpp
+++ b/example/Dynamite/context.cpp
@@ -81,7 +81,6 @@ void Context::update(bool add, std::string blockname) {
 
 bool port_iterator(Block& b, std::vector<Link>::iterator link_iter) {
     for (auto& p : b._inPorts) {
-        printf("comparing link end attr %d to port id %d on block %d\n", link_iter->end_attr, p.first, b.getID());
         if (p.first == link_iter->end_attr) {
             return true;
         } else {
@@ -109,9 +108,6 @@ void Context::buildGraph() {
                 if (block_iter != _blocks.end()) {
                     if (!m_graph.contains_edge(block.getID(), block_iter->getID())) {
                         m_graph.add_edge(block.getID(), block_iter->getID());
-                        // move on to serialization by breadth first
-                        // when a branch diverges, print block up until the path unites again from where it broke off, a
-                        // then go back to the reference where it splits and print those until the convergence point
                     }
                 } 
             }         

--- a/example/Dynamite/context.cpp
+++ b/example/Dynamite/context.cpp
@@ -116,7 +116,6 @@ void Context::buildGraph() {
                 } 
             }         
         }
-        printf("\n\n");
     }
     m_graph.display();
 }

--- a/example/Dynamite/context.cpp
+++ b/example/Dynamite/context.cpp
@@ -1,14 +1,13 @@
 #include "context.h"
 #include "dyndsp_wrapper.h"
 #include <SDL_scancode.h>
-
-// Retrieve from DyndspWrapper
-//extern struct DynDSPData;
+#include <iostream>
 
 struct BlockNames names;
 struct BlockParameters parameters;
 
-Context::Context() {}
+Context::Context() {
+}
 
 /*Context::~Context() {
     ImNodes::EditorContextFree(m_context);
@@ -80,10 +79,46 @@ void Context::update(bool add, std::string blockname) {
     }
 }
 
-int Context::addBlock() {
-    const int block_id = ++current_block_id;
-    _blocks.push_back(Block(block_id, "DSPBlock")); // load names from block library
-    return block_id;
+bool port_iterator(Block& b, std::vector<Link>::iterator link_iter) {
+    for (auto& p : b._inPorts) {
+        printf("comparing link end attr %d to port id %d on block %d\n", link_iter->end_attr, p.first, b.getID());
+        if (p.first == link_iter->end_attr) {
+            return true;
+        } else {
+            continue;
+        }
+    }
+    return false;
+}
+
+void Context::buildGraph() {
+    // initialize graph
+    m_graph = Graph(_blocks.back().getID() + 1); 
+
+    for (auto& block : _blocks) {
+        for (auto& port : block._outPorts) {
+            auto link_iter = std::find_if(
+                _links.begin(), _links.end(), [port](const Link& temp) -> bool {
+                    return port.first == temp.start_attr;
+            });
+            if (link_iter != _links.end()) {
+                auto block_iter = std::find_if(
+                    _blocks.begin(), _blocks.end(), [link_iter](Block& b) -> bool {
+                            return port_iterator(b, link_iter);
+                });
+                if (block_iter != _blocks.end()) {
+                    if (!m_graph.contains_edge(block.getID(), block_iter->getID())) {
+                        m_graph.add_edge(block.getID(), block_iter->getID());
+                        // move on to serialization by breadth first
+                        // when a branch diverges, print block up until the path unites again from where it broke off, a
+                        // then go back to the reference where it splits and print those until the convergence point
+                    }
+                } 
+            }         
+        }
+        printf("\n\n");
+    }
+    m_graph.display();
 }
 
 void Context::deleteBlock(int node_id) {
@@ -114,7 +149,6 @@ void Context::addLink() {
                         }
                     }
                 }
-                
                 _links.erase(iter);
             }
         }

--- a/example/Dynamite/context.h
+++ b/example/Dynamite/context.h
@@ -3,6 +3,7 @@
 #include <imgui.h>
 #include <imnodes.h>
 #include "block.h"
+#include "graph.h"
 
 #include <vector>
 #include <map>
@@ -29,6 +30,8 @@ struct Link
 
 class Context {
 
+    Graph m_graph;
+
 public:
 
     ImNodesEditorContext* m_context = nullptr;
@@ -47,8 +50,9 @@ public:
         Context();
         //~Context();
         void init();
-        void loadContext(); 
+        void loadContext();     // to be defined when the reverse deployment process is implemented
         void update(bool add, std::string blockname);
+        void buildGraph();
         int addBlock();
         void deleteBlock(int node_id);
         void addLink();

--- a/example/Dynamite/graph.cpp
+++ b/example/Dynamite/graph.cpp
@@ -1,0 +1,53 @@
+#include "graph.h"
+
+#include <iostream>
+
+using namespace std;
+
+struct adjlist_node;
+struct adjlist;
+
+Graph::Graph() {
+}
+
+void Graph::init(int num_vertices) {
+    // when num_vertices is grabbed as _blocks.size()
+    this->num_vertices = num_vertices;
+}
+
+adjlist_node* Graph::new_node(int dest) {
+    adjlist_node* newNode = new adjlist_node;
+    newNode->dest = dest;
+    newNode->next = NULL;
+    return newNode;
+}
+
+void Graph::add_edge(int src, int dest) {
+    adjlist_node* newNode = new_node(dest);
+    newNode->next = array[src].head;
+    array[src].head = newNode;
+}
+
+void Graph::display() {
+    int v;
+    for (v = 0; v < num_vertices; ++v)
+    {
+        adjlist_node* pCrawl = array[v].head;
+        cout<<"\n Adjacency list of vertex "<<v<<"\n head ";
+        while (pCrawl)
+        {
+            cout<<"-> "<<pCrawl->dest;
+            pCrawl = pCrawl->next;
+        }
+        cout<<endl;
+    }
+}
+
+bool Graph::contains_edge(int src, int dest) {
+    for (adjlist_node* node = array[src].head; node; node = node->next) {
+        if (node->dest == dest) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/example/Dynamite/graph.h
+++ b/example/Dynamite/graph.h
@@ -1,0 +1,35 @@
+#include <list>
+
+#include "block.h"
+
+struct adjlist_node {
+    int dest;
+    struct adjlist_node* next;
+};
+
+struct adjlist {
+    struct adjlist_node* head;
+};
+
+class Graph {
+
+    private:
+        int num_vertices;
+        struct adjlist* array;
+
+    public: 
+        Graph();
+        Graph(int v) {
+            this->num_vertices = v;
+            array = new adjlist[v];
+            for (int i = 0; i<v; i++) {
+                array[i].head = NULL;
+            }
+        }
+        void init(int num_vertices);
+        adjlist_node* new_node(int dest);
+        void add_edge(int src, int dest);
+        void display();
+        bool contains_edge(int src, int dest);
+
+};

--- a/example/Dynamite/menubar.cpp
+++ b/example/Dynamite/menubar.cpp
@@ -86,6 +86,8 @@ void MenuBar::show(Context& m_context, DyndspWrapper m_wrapper) {
 }
 
 static void saveToJson(Context& m_context) {
+    m_context.buildGraph();
+    
     JsonGraphFileWriter fw;
     fw.writeToFile(m_context);
     save = false;


### PR DESCRIPTION
**Overview**

As a developer, I would like to build an adjacency list out of a block diagram to store what vertices (blocks) are connected by which edges (links). This will greatly simplify, and correct, the order in which we serialize blocks into json, taking into account the links in between blocks and well as when paths diverge from a block and converge into another block. I have determined that the diagram can be described as a directed acrylic graph, where when a directed edge connects vertex u to v, u must be sorted before v. The next step is to implement a BFS on the adjacency list.

**Test**

Build a system in the editor. When you run the `save` command, the adjacency list for that system will be printed to the terminal. Try building unnecessarily complex systems, deleting random blocks and re-adding them out of order, and make sure the program doesn't seg fault. 

**Notes**
1. The adjacency list will be shouldn't be too difficult to follow unless you build a super large system or lose track of which block ids correspond to which block name. 

Link to Jira: [https://jira.sonos.com/browse/SWPBL-190856](url)